### PR TITLE
Bug-fix: Resolved GET all Categories from API.

### DIFF
--- a/controllers/category.js
+++ b/controllers/category.js
@@ -30,7 +30,7 @@ exports.getCategory = (req , res) => {
 }
 
 exports.getAllCategory = (req,res) => {
-    Category.findById().exec( (err,categories) => {
+    Category.find().exec( (err,categories) => {
         if(err){
             return res.status(400).json({
                 error: "NO categories found"


### PR DESCRIPTION
**Issue Cause:** The controller that handles getting all category data was having a _'findById()'_ method which requires 'id' as an argument. Hence the response was always sent as _'null_'.

**Solution:** By replacing _'findById()'_  with _'find()'_ solves the issue and the response contains all the categories data stored in the DB.